### PR TITLE
Add guzzle adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-### 1.0.2 (????-??-??)
+### 1.0.3 (2013-09-13)
+
+* 9ab5b1a - Add Guzzle support
+
+### 1.0.2 (2013-09-09)
 
  * c47befd - Add stream support
 

--- a/Model/GuzzleHttpAdapter.php
+++ b/Model/GuzzleHttpAdapter.php
@@ -1,0 +1,77 @@
+<?php
+
+
+namespace Widop\HttpAdapterBundle\Model;
+
+
+use Guzzle\Http\ClientInterface;
+use Guzzle\Http\Exception\RequestException;
+use Widop\HttpAdapterBundle\Exception\HttpAdapterException;
+
+/**
+ * Guzzle Http adapter.
+ *
+ * @author Gunnar Lium <gunnarlium@gmail.com>
+ */
+class GuzzleHttpAdapter implements HttpAdapterInterface
+{
+    /** @var  ClientInterface */
+    protected $client;
+
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Gets the content fetched from the given URL.
+     *
+     * @param string $url The URL to request.
+     * @param array $headers HTTP headers (optionnal).
+     *
+     * @throws \Exception If an error occured.
+     *
+     * @return string The fetched content.
+     */
+    public function getContent($url, array $headers = array())
+    {
+        try {
+            $response = $this->client->get($url, $headers)->send();
+            return $response->getBody(true);
+        } catch (RequestException $e) {
+            throw HttpAdapterException::cannotFetchUrl($url, $this->getName(), $e->getMessage());
+        }
+    }
+
+    /**
+     * Gets the content fetched from the given url & POST datas.
+     *
+     * @param string $url The URL to request.
+     * @param array $headers HTTP headers (optional).
+     * @param string $content The POST content (optional).
+     *
+     * @throws \Exception If an error occured.
+     *
+     * @return string The fetched content.
+     */
+    public function postContent($url, array $headers = array(), $content = '')
+    {
+        try {
+            $response = $this->client->post($url, $headers, $content)->send();
+            return $response->getBody(true);
+        } catch (RequestException $e) {
+            throw HttpAdapterException::cannotFetchUrl($url, $this->getName(), $e->getMessage());
+        }
+    }
+
+    /**
+     * Gets the name of the Http adapter.
+     *
+     * @return string The Http adapter name.
+     */
+    public function getName()
+    {
+        return 'guzzle';
+    }
+
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The bundle allows to issue HTTP requests. Currently, the supported adapters are:
  - [Buzz](https://github.com/kriswallsmith/Buzz)
  - [cURL](http://curl.haxx.se/)
  - [Stream](http://php.net/manual/en/book.stream.php)
+ - [Guzzle](http://guzzlephp.org/)
 
 Documentation
 -------------

--- a/Tests/Model/AbstractHttpAdapterTest.php
+++ b/Tests/Model/AbstractHttpAdapterTest.php
@@ -49,13 +49,13 @@ abstract class AbstractHttpAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testGetContentWithoutHeaders()
     {
-        $this->assertNotEmpty($this->httpAdapter->getContent('www.google.fr'));
+        $this->assertNotEmpty($this->httpAdapter->getContent('http://www.google.fr'));
     }
 
     public function testGetContentWithHeaders()
     {
         $this->assertNotEmpty($this->httpAdapter->getContent(
-            'www.google.fr',
+            'http://www.google.fr',
             array('Accept-Charset' => 'utf-8', 'Accept-Language: en-US,en;q=0.8'))
         );
     }
@@ -70,13 +70,13 @@ abstract class AbstractHttpAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testPostContentWithoutHeaders()
     {
-        $this->assertNotEmpty($this->httpAdapter->postContent('www.widop.com'));
+        $this->assertNotEmpty($this->httpAdapter->postContent('http://www.widop.com'));
     }
 
     public function testPostContentWithHeaders()
     {
         $this->assertNotEmpty($this->httpAdapter->postContent(
-            'www.widop.com',
+            'http://www.widop.com',
             array('Accept-Charset' => 'utf-8', 'Accept-Language: en-US,en;q=0.8'))
         );
     }
@@ -85,7 +85,7 @@ abstract class AbstractHttpAdapterTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertNotEmpty(
             $this->httpAdapter->postContent(
-                'www.widop.fr',
+                'http://www.widop.fr',
                 array('Accept-Charset' => 'utf-8', 'Accept-Language: en-US,en;q=0.8'),
                 http_build_query(array('param' => 'value'))
             )

--- a/Tests/Model/GuzzleHttpAdapterTest.php
+++ b/Tests/Model/GuzzleHttpAdapterTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Wid'op package.
+ *
+ * (c) Wid'op <contact@widop.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Widop\HttpAdapterBundle\Tests\Model;
+
+use Guzzle\Http\Client;
+use Widop\HttpAdapterBundle\Model\GuzzleHttpAdapter;
+
+/**
+ * Buzz http adapter test.
+ *
+ * @author Gunnar Lium <gunnarlium@gmail.com>
+ */
+class GuzzleHttpAdapterTest extends AbstractHttpAdapterTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $client = new Client();
+        $this->httpAdapter = new GuzzleHttpAdapter($client);
+    }
+
+    public function testName()
+    {
+        $this->assertSame('guzzle', $this->httpAdapter->getName());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,10 @@
         {
             "name": "Eric GELOEN",
             "email": "geloen.eric@gmail.com"
+        },
+        {
+            "name": "Gunnar Lium",
+            "email": "gunnarlium@gmail.com"
         }
     ],
     "require": {
@@ -19,10 +23,12 @@
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
-        "kriswallsmith/buzz": "0.*"
+        "kriswallsmith/buzz": "0.*",
+        "guzzle/guzzle": "~3.1"
     },
     "suggest": {
         "kriswallsmith/buzz": "Allows you to use Buzz adapter",
+        "guzzle/guzzle"     : "Allows you to use Guzzle adapter",
         "ext-curl"          : "Allows you to use cURL adapter"
     },
     "autoload": {


### PR DESCRIPTION
This PR adds a new Guzzle adapater.

I've also changed the tests to use `http://`-prefixed urls. Guzzle requires this, and I think it makes more sense. It would be trivial to patch the adapter to prefix schemeless urls with `http://`, but I don't think it adds any value.

All tests are still passing.
