### PR TITLE
Update dependencies to support Symfony 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 language: php
 
 php:
-    - 5.3.3
-    - 5.3
-    - 5.4
     - 5.5
+    - 5.6
+    - 7.0
 
 env:
-    - SYMFONY_VERSION="2.0.*"
-    - SYMFONY_VERSION="2.1.*"
-    - SYMFONY_VERSION="2.2.*"
     - SYMFONY_VERSION="2.3.*"
+    - SYMFONY_VERSION="3.0.*"
 
 before_script:
     - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "2.*",
+        "symfony/framework-bundle": "~2.3|~3.0",
         "widop/http-adapter": "1.1.*"
     },
     "require-dev": {
@@ -23,7 +23,8 @@
         "ext-curl": "*",
         "kriswallsmith/buzz": "*",
         "guzzle/guzzle": "*",
-        "zendframework/zend-http": "*"
+        "zendframework/zend-http": "*",
+        "php": ">=5.5.9"
     },
     "autoload": {
         "psr-0": { "Widop\\HttpAdapterBundle": "" }


### PR DESCRIPTION
Hey, our team is using the IvoryGoogleMapBundle, and currently in order to upgrade to Symfony 3, the composer versions need to be bumped on both projects. I've made this pull request in hope that this way, I can also submit another to IvoryGoogleMapBundle, and thus upgrade both projects. 

I've tested using the ~3.0 dependencies and all tests run fine :+1: but I had to increase the PHP versions being tested within Travis's config. 

I would like to propose a new stable tag (2.0), so that it's easy to fix strictly within composer's deps.

Also below the output from the deprecation checker:

```
Checking your application for deprecations - this could take a while ...
Loading RuleSet...
RuleSet loaded.
Parsing files & Searching for deprecations...
Finished searching for deprecations.
Rendering output...
Finished rendering output.

There are no violations - congratulations!
Checked 3 source files in 3.272 seconds, 17.75 MB memory used
```
